### PR TITLE
Fix bug that opens options page even if the settings are correct.

### DIFF
--- a/src/lib/main.js
+++ b/src/lib/main.js
@@ -123,7 +123,6 @@ exports.main = function(options, callbacks) {
                         }
                     },
                     failure: function(response) {
-
                         // Emit a message so that options.js can modify the HTML and
                         // inform the user to verify his credentials.
                         worker.port.emit("pingFailed", response.json);
@@ -155,8 +154,5 @@ exports.main = function(options, callbacks) {
             url: data.url('options.html'),
             onLoad: attach
         });
-
-    } else if (options.loadReason === "uninstall") {
-        storage.save("savedPrefs", false);
     }
 };

--- a/src/lib/preferences.js
+++ b/src/lib/preferences.js
@@ -15,9 +15,11 @@ var init = function(prefs, api, storage) {
     function onPrefChange(prefName) {
         api.ping({
             success:  function(response) {
+                storage.save("savedPrefs", true);
                 console.log("The " + prefName + " preference changed.");
             },
             failure: function(response) {
+                storage.save("savedPrefs", false);
                 console.log(
                     "The ping command failed. " +
                     "Please check your api url, username, and api_key. " +

--- a/src/lib/storage.js
+++ b/src/lib/storage.js
@@ -13,8 +13,7 @@ var Storage = function() {
         console.log('checking for key: ' + key);
         console.log('did we find it?');
         console.log(extStorage[key]);
-        console.log(extStorage[key]);
-
+        
         return extStorage[key];
     };
 


### PR DESCRIPTION
User might use the Add-On Manager to set the preferences. Earlier version doesn't update the flag and on restart, the extension is forced to open the options page.

This does not happen if you have saved the preferences using the options page for the first time.

Also, when the user modifies the preferences there is no visual indication in the Add-On manager about the validity of the settings. He discovers the same only when he tries to bookmarks something. This change makes sure that the options page opens up when the extension reloads.
