### PR TITLE
Periodic bmark sync

### DIFF
--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -99,6 +99,27 @@ exports.BookieApi = function (config) {
         sync: function (callbacks, bind_scope) {
             var api_url_append = "/extension/sync";
             _api.get(api_url_append, {}, callbacks, bind_scope);
+        },
+
+        checkNew: function(lastSync, savedPrefs, interval, bind_scope) {
+            if (lastSync && ((new Date()).getTime() - lastSync > interval) ||
+                (!lastSync && savedPrefs)) {
+                
+                this.sync({
+                    success: function(resp) {
+                        resp.json.hash_list.forEach(function(key) {
+                            bind_scope.storage.save(key, true);
+                        });
+
+                        // Update the last sync flag here.
+                        bind_scope.storage.save('lastSync', (new Date()).getTime());
+                    },
+                    failure: function(resp) {
+                        console.log('sync fail');
+                        console.log(resp.json);
+                    }
+                }, bind_scope);
+            }
         }
     };
 

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -101,6 +101,17 @@ exports.BookieApi = function (config) {
             _api.get(api_url_append, {}, callbacks, bind_scope);
         },
 
+        /**
+         * Helper for updating the bmark hash list periodically.
+         * Based on the params below it syncs the bmark list in localStorage
+         * 
+         * @method checkNew
+         * @param {Integer} lastSync Last Synced timestamp
+         * @param {Boolean} savedPrefs Do we have valid preferences on file?
+         * @param {Integer} Time period to check if it has elapsed
+         * @param {Object} bind_scope A scope containing the storage object
+         * 
+         */
         checkNew: function(lastSync, savedPrefs, interval, bind_scope) {
             if (lastSync && ((new Date()).getTime() - lastSync > interval) ||
                 (!lastSync && savedPrefs)) {

--- a/src/lib/main.js
+++ b/src/lib/main.js
@@ -77,17 +77,18 @@ var showBmarkPanel = Hotkey({
 
 exports.main = function(options, callbacks) {
 
-    // Allow upto a minute for the extension to download the hashes and 
+    // Allow up to a minute for the extension to download the hashes and 
     // update them in the local storage. Otherwise, the intervals after
     // which the hashes are updated is nearly doubled.
-    var interval = (86400 + 60)*1000,
+    var minute = 60 * 1000,
+        interval = (86400 * 1000) + minute,
         api = BookieApi(prefs.prefs),
         that = {
             storage: storage
         };
 
     api.checkNew(storage.get('lastSync'), storage.get('savedPrefs'),
-        interval - (60*1000), that);
+        interval - minute, that);
 
     // The reason why preferences, lastSync, savedPrefs 
     // are not cached is that they can change over a period of time.
@@ -96,7 +97,7 @@ exports.main = function(options, callbacks) {
     var handle = timer.setInterval(function() {
         var api = BookieApi(prefs.prefs);
         api.checkNew(storage.get('lastSync'), storage.get('savedPrefs'),
-            interval - (60*1000), that);
+            interval - minute, that);
     }, interval);
 
     // When the extension is first installed, take the user to the options

--- a/src/lib/main.js
+++ b/src/lib/main.js
@@ -3,6 +3,7 @@ var data = require("sdk/self").data,
     tabs = require("sdk/tabs"),
     widgets = require("sdk/widget"),
     BookieApi = require('./api').BookieApi,
+    timer = require('sdk/timers'),
     api = BookieApi(prefs.prefs),
    { Hotkey } = require("sdk/hotkeys");
 
@@ -74,8 +75,30 @@ var showBmarkPanel = Hotkey({
     }
 });
 
-
 exports.main = function(options, callbacks) {
+
+    // Allow upto a minute for the extension to download the hashes and 
+    // update them in the local storage. Otherwise, the intervals after
+    // which the hashes are updated is nearly doubled.
+    var interval = (86400 + 60)*1000,
+        api = BookieApi(prefs.prefs),
+        that = {
+            storage: storage
+        };
+
+    api.checkNew(storage.get('lastSync'), storage.get('savedPrefs'),
+        interval - (60*1000), that);
+
+    // The reason why preferences, lastSync, savedPrefs 
+    // are not cached is that they can change over a period of time.
+    // In the worst case, the hash list will remain out of sync for 
+    // a period of 47 hours. 
+    var handle = timer.setInterval(function() {
+        var api = BookieApi(prefs.prefs);
+        api.checkNew(storage.get('lastSync'), storage.get('savedPrefs'),
+            interval - (60*1000), that);
+    }, interval);
+
     // When the extension is first installed, take the user to the options
     // page like in the chrome extensions and have him fill the settings.
     // Check for the savedPrefs flag every single time the extensions starts
@@ -103,10 +126,17 @@ exports.main = function(options, callbacks) {
 
             worker.port.on("savePreferences", function(prefData) {
 
-                var api = BookieApi(prefData);
+                var api = BookieApi(prefData),
+                    that = {
+                        storage: storage
+                    };
+
                 api.ping({
                     success: function(response) {
                         if (response.json.success) {
+                            var that = {
+                                storage: storage
+                            };
 
                             // Update the preferences using the preference service.
                             var newPrefs = prefs.prefs;
@@ -119,6 +149,8 @@ exports.main = function(options, callbacks) {
                             prefs.prefs = newPrefs;
                             storage.save("savedPrefs", true);
 
+                            // Force update.
+                            api.checkNew(0, true, 0, that);
                             worker.port.emit("pingSucceeded");
                         }
                     },
@@ -139,6 +171,9 @@ exports.main = function(options, callbacks) {
                             storage.save(key, true);
                             worker.port.emit("syncSuccess");
                         });
+
+                        // Update the last sync flag here.
+                        storage.save('lastSync',(new Date()).getTime());
                     },
                     failure: function(resp) {
                         console.log('sync fail');
@@ -160,3 +195,4 @@ exports.main = function(options, callbacks) {
         storage.save("savedPrefs", false);
     }
 };
+    

--- a/src/lib/preferences.js
+++ b/src/lib/preferences.js
@@ -5,6 +5,10 @@ console.log(preferenceData);
 
 var init = function(prefs, api, storage) {
     
+    var that = {
+        storage: storage
+    };
+
     // Add a listener only when the following changes
     // Changes in cache_content key don't really matter.
     prefs.on("api_key", onPrefChange);
@@ -14,10 +18,15 @@ var init = function(prefs, api, storage) {
     
     function onPrefChange(prefName) {
         api.ping({
-            success:  function(response) {
+            success: function(response) {
+                storage.save('savedPrefs', true);
                 console.log("The " + prefName + " preference changed.");
+                
+                // Force update as preferences have been updated.
+                api.checkNew(0, true, 0, that);
             },
             failure: function(response) {
+                storage.save('savedPrefs', false);
                 console.log(
                     "The ping command failed. " +
                     "Please check your api url, username, and api_key. " +
@@ -37,6 +46,8 @@ var init = function(prefs, api, storage) {
                 resp.json.hash_list.forEach(function(key) {
                     storage.save(key, true);
                 });
+
+                storage.save('lastSync', (new Date()).getTime());
             },
             failure: function(resp) {
                 console.log('sync fail');

--- a/src/lib/storage.js
+++ b/src/lib/storage.js
@@ -13,8 +13,7 @@ var Storage = function() {
         console.log('checking for key: ' + key);
         console.log('did we find it?');
         console.log(extStorage[key]);
-        console.log(extStorage[key]);
-
+        
         return extStorage[key];
     };
 


### PR DESCRIPTION
Chrome extension implementation should follow this. However, that requires usage of chrome.storage as outlined in https://github.com/bookieio/bookie/pull/345.

https://docs.google.com/file/d/0B1C0uR7ajU7ndFc3Y1hZUGxnejA/edit?pli=1

The above link contains the xpi file for quick testing.

@widox, @mitechie
